### PR TITLE
incorrect parameters to functions is_callable and call_user_func

### DIFF
--- a/src/I18Next/Translator.php
+++ b/src/I18Next/Translator.php
@@ -278,8 +278,9 @@ class Translator {
                     $lngs[] = $options['lng'] ?? $this->_language;
 
                 $send = function($l, $k) use ($namespace, $updateMissing, $options, $res) {
-                    if (isset($this->_options['missingKeyHandler']) && is_callable([$this->_options, 'missingKeyHandler'])) {
-                        call_user_func([$this->_options, 'missingKeyHandler'], $l, $namespace, $k, $updateMissing ? $options['defaultValue'] ?? null : $res, $updateMissing, $options);
+                    if (isset($this->_options['missingKeyHandler']) && is_callable($this->_options['missingKeyHandler'])) {
+                        call_user_func($this->_options['missingKeyHandler'], $l, $namespace, $k, $updateMissing ? $options['defaultValue'] ?? null : $res,
+                            $updateMissing, $options);
                     }
                     else if ($this->_translationLoadManager !== null) {
                         $this->_translationLoadManager->saveMissing($l, $namespace, $k, $updateMissing ? $options['defaultValue'] ?? null : $res, $updateMissing, $options);


### PR DESCRIPTION
The missingKeyHandler callback function does not work as expected due to incorrect function call in the Translator class